### PR TITLE
feat: ingest multiple rss feeds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "jest": "^29.7.0",
         "prettier": "^3.2.5",
         "react": "^18.2.0",
+        "rss-parser": "^3.12.0",
         "ts-jest": "^29.1.1",
         "typescript": "^5.4.5"
       }
@@ -2735,6 +2736,16 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -6178,6 +6189,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rss-parser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
+      "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.0.3",
+        "xml2js": "^0.5.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6256,6 +6278,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -7341,6 +7370,30 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^29.7.0",
+    "rss-parser": "^3.12.0",
     "prettier": "^3.2.5",
     "react": "^18.2.0",
     "ts-jest": "^29.1.1",

--- a/supabase/functions/ingestNews/index.ts
+++ b/supabase/functions/ingestNews/index.ts
@@ -1,10 +1,10 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import Parser from 'https://esm.sh/rss-parser@3.12.0';
+import { fetchFeeds } from './utils.ts';
 
 serve(async () => {
   const parser = new Parser();
-  const feed = await parser.parseURL('https://ra.co/rss');
-  const items = feed.items.slice(0, 10).map((i) => ({ title: i.title, link: i.link }));
+  const items = await fetchFeeds(parser);
   return new Response(JSON.stringify(items), {
     headers: { 'Content-Type': 'application/json' }
   });

--- a/supabase/functions/ingestNews/utils.test.ts
+++ b/supabase/functions/ingestNews/utils.test.ts
@@ -1,0 +1,15 @@
+import { fetchFeeds } from './utils';
+
+test('fetchFeeds dedupes and caps items per feed', async () => {
+  const parser = {
+    parseURL: async () => ({
+      items: Array.from({ length: 12 }, (_, i) => ({
+        title: `title${i}`,
+        link: `link${i % 5}`
+      }))
+    })
+  };
+  const items = await fetchFeeds(parser, ['https://example.com/rss']);
+  expect(items).toHaveLength(5);
+  expect(items[0].source).toBe('example.com');
+});

--- a/supabase/functions/ingestNews/utils.ts
+++ b/supabase/functions/ingestNews/utils.ts
@@ -1,0 +1,40 @@
+export const FEED_URLS = [
+  'https://ra.co/xml/rss.xml',
+  'https://mixmag.net/rss.xml',
+  'https://djmag.com/rss.xml'
+];
+
+export interface NewsItem {
+  title: string;
+  link: string;
+  source: string;
+}
+
+interface ParserLike {
+  parseURL(url: string): Promise<{ items?: Array<{ title?: string; link?: string }> }>;
+}
+
+export async function fetchFeeds(
+  parser: ParserLike,
+  feedUrls: string[] = FEED_URLS
+): Promise<NewsItem[]> {
+  const feeds = await Promise.all(
+    feedUrls.map(async (url) => {
+      const feed = await parser.parseURL(url);
+      const source = new URL(url).hostname;
+      return (feed.items || []).slice(0, 10).map((item) => ({
+        title: item.title ?? '',
+        link: item.link ?? '',
+        source
+      }));
+    })
+  );
+
+  const deduped = new Map<string, NewsItem>();
+  for (const item of feeds.flat()) {
+    if (item.link && !deduped.has(item.link)) {
+      deduped.set(item.link, item);
+    }
+  }
+  return Array.from(deduped.values());
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,15 @@
     "jsx": "react-jsx",
     "lib": ["ES2021", "DOM"]
   },
-  "include": ["shared/**/*", "supabase/seed.ts"],
-  "exclude": ["node_modules", "mobile/**/*", "admin/**/*", "supabase/functions/**/*"]
+  "include": [
+    "shared/**/*",
+    "supabase/seed.ts",
+    "supabase/functions/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "mobile/**/*",
+    "admin/**/*",
+    "supabase/functions/**/index.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- add reusable feed utility to normalize and dedupe items from multiple RSS sources
- integrate utility with `ingestNews` edge function
- type-check Supabase functions and add unit test

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b33e1a69e4832f8477b649c6a6a951