### PR TITLE
feat: enrich news ingest with categorization and scheduling

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,3 @@
+[functions.ingestNews]
+verify_jwt = false
+schedule = "*/30 * * * *"

--- a/supabase/functions/ingestNews/index.ts
+++ b/supabase/functions/ingestNews/index.ts
@@ -1,11 +1,28 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import Parser from 'https://esm.sh/rss-parser@3.12.0';
-import { fetchFeeds } from './utils.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { fetchFeeds, inferCategory, inferRegion } from './utils.ts';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+const supabase = createClient(supabaseUrl, supabaseKey);
+const kv = await Deno.openKv();
 
 serve(async () => {
   const parser = new Parser();
   const items = await fetchFeeds(parser);
-  return new Response(JSON.stringify(items), {
+  const enriched = items.map((i) => ({
+    ...i,
+    category: inferCategory(i),
+    region: inferRegion(i)
+  }));
+
+  for (const item of enriched) {
+    await supabase.from('news').upsert(item, { onConflict: 'link' });
+    await kv.set(['news', item.link], item, { expireIn: 1000 * 60 * 30 });
+  }
+
+  return new Response(JSON.stringify(enriched), {
     headers: { 'Content-Type': 'application/json' }
   });
 });

--- a/supabase/functions/ingestNews/utils.test.ts
+++ b/supabase/functions/ingestNews/utils.test.ts
@@ -1,4 +1,4 @@
-import { fetchFeeds } from './utils';
+import { fetchFeeds, inferCategory, inferRegion } from './utils';
 
 test('fetchFeeds dedupes and caps items per feed', async () => {
   const parser = {
@@ -12,4 +12,14 @@ test('fetchFeeds dedupes and caps items per feed', async () => {
   const items = await fetchFeeds(parser, ['https://example.com/rss']);
   expect(items).toHaveLength(5);
   expect(items[0].source).toBe('example.com');
+});
+
+test('infers category and region from title', () => {
+  const item = {
+    title: 'Berlin festival announces lineup',
+    link: '',
+    source: ''
+  };
+  expect(inferCategory(item)).toBe('events');
+  expect(inferRegion(item)).toBe('europe');
 });

--- a/supabase/functions/ingestNews/utils.ts
+++ b/supabase/functions/ingestNews/utils.ts
@@ -8,6 +8,8 @@ export interface NewsItem {
   title: string;
   link: string;
   source: string;
+  category?: string;
+  region?: string;
 }
 
 interface ParserLike {
@@ -37,4 +39,36 @@ export async function fetchFeeds(
     }
   }
   return Array.from(deduped.values());
+}
+
+const CATEGORY_KEYWORDS: Record<string, string[]> = {
+  events: ['festival', 'gig', 'event'],
+  releases: ['album', 'track', 'release'],
+  features: ['interview', 'feature']
+};
+
+export function inferCategory(item: NewsItem): string {
+  const lower = item.title.toLowerCase();
+  for (const [category, keywords] of Object.entries(CATEGORY_KEYWORDS)) {
+    if (keywords.some((k) => lower.includes(k))) {
+      return category;
+    }
+  }
+  return 'general';
+}
+
+const REGION_KEYWORDS: Record<string, string[]> = {
+  europe: ['berlin', 'london', 'paris'],
+  asia: ['bangalore', 'mumbai', 'tokyo'],
+  america: ['new york', 'los angeles', 'chicago']
+};
+
+export function inferRegion(item: NewsItem): string {
+  const lower = item.title.toLowerCase();
+  for (const [region, keywords] of Object.entries(REGION_KEYWORDS)) {
+    if (keywords.some((k) => lower.includes(k))) {
+      return region;
+    }
+  }
+  return 'global';
 }


### PR DESCRIPTION
## Summary
- store and cache RSS feed items with inferred category and region
- schedule `ingestNews` to run every 30 minutes

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b34073c250832f836649d4ad9bc421