### PR TITLE
feat: centralize design tokens

### DIFF
--- a/mobile/src/screens/Feed.tsx
+++ b/mobile/src/screens/Feed.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, FlatList, Image, Pressable } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
+import { theme } from '../../../shared/theme';
 
 const posts = [
   { id: '1', type: 'text', content: 'Welcome to thecueRoom!' },
@@ -18,7 +19,7 @@ export default function Feed() {
       renderItem={({ item }) => (
         <View style={{ padding: 16 }}>
           {item.type === 'text' ? (
-            <Text style={{ color: 'white' }}>{item.content}</Text>
+            <Text style={{ color: theme.colors.fg }}>{item.content}</Text>
           ) : (
             <Image source={{ uri: item.content }} style={{ width: 200, height: 200 }} />
           )}
@@ -30,7 +31,7 @@ export default function Feed() {
             }}
           >
             <Animated.View
-              style={[{ width: 20, height: 20, backgroundColor: '#D1FF3D', marginTop: 8 }, anim]}
+              style={[{ width: 20, height: 20, backgroundColor: theme.colors.lime, marginTop: 8 }, anim]}
             />
           </Pressable>
         </View>

--- a/mobile/src/screens/News.tsx
+++ b/mobile/src/screens/News.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { FlatList, Text } from 'react-native';
 import Parser from 'rss-parser';
+import { theme } from '../../../shared/theme';
 
 export default function News() {
   const [items, setItems] = useState<{ title?: string }[]>([]);
@@ -14,7 +15,9 @@ export default function News() {
     <FlatList
       data={items}
       keyExtractor={(item, idx) => String(idx)}
-      renderItem={({ item }) => <Text style={{ color: 'white', padding: 8 }}>{item.title}</Text>}
+      renderItem={({ item }) => (
+        <Text style={{ color: theme.colors.fg, padding: 8 }}>{item.title}</Text>
+      )}
     />
   );
 }

--- a/mobile/src/screens/Profile.tsx
+++ b/mobile/src/screens/Profile.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import Logo from '../../../shared/Logo';
+import { theme } from '../../../shared/theme';
 
 export default function Profile() {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Logo />
-      <Text style={{ color: 'white', marginTop: 16 }}>User Profile</Text>
+      <Text style={{ color: theme.colors.fg, marginTop: 16 }}>User Profile</Text>
     </View>
   );
 }

--- a/mobile/src/screens/Studio.tsx
+++ b/mobile/src/screens/Studio.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import { theme } from '../../../shared/theme';
 
 export default function Studio() {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text style={{ color: 'white' }}>Studio: Meme Generator coming soon</Text>
+      <Text style={{ color: theme.colors.fg }}>Studio: Meme Generator coming soon</Text>
     </View>
   );
 }

--- a/shared/theme.test.ts
+++ b/shared/theme.test.ts
@@ -1,5 +1,5 @@
 import { theme } from './theme';
 
-test('theme has lime primary', () => {
-  expect(theme.colors.primary).toBe('#D1FF3D');
+test('theme exposes lime color', () => {
+  expect(theme.colors.lime).toBe('#D1E231');
 });

--- a/shared/theme.ts
+++ b/shared/theme.ts
@@ -1,17 +1,24 @@
 export const theme = {
   colors: {
-    background: '#0B0B0B',
-    surface: '#111111',
-    primary: '#D1FF3D',
-    accent: '#873BBF',
-    text: '#FFFFFF',
-    textMuted: '#C7C7C7',
-    border: '#1E1E1E'
+    bg: '#080808',
+    fg: '#E6E6E6',
+    muted: '#0F0F0F',
+    grid: '#161616',
+    card: '#0B0B0B',
+    border: '#151515',
+    lime: '#D1E231',
+    purple: '#873BBF',
+    white: '#FFFFFF'
   },
   fonts: {
     heading: 'Inter-Black',
     body: 'Inter-Regular',
     mono: 'SourceCodePro-Regular'
+  },
+  animations: {
+    driftSlow: 36000,
+    driftMed: 28000,
+    blink: 10000
   }
 } as const;
 


### PR DESCRIPTION
## Summary
- add shared theme with global color and motion tokens
- refactor mobile screens to consume theme colors

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b344acf278832fa1d5bbc12f426481