### PR TITLE
chore: exclude Deno client from TypeScript checks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "node_modules",
     "mobile/**/*",
     "admin/**/*",
-    "supabase/functions/**/index.ts"
+    "supabase/functions/**/index.ts",
+    "supabase/functions/utils/client.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- exclude Deno-based Supabase client from Node typecheck
- tidy tsconfig formatting

## Testing
- `npm run typecheck`
- `npm run lint`
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b34856e964832fbbc0a959d1f4998d