### PR TITLE
chore: add supabase token, android package, and deno check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ NEXT_PUBLIC_SUPABASE_URL=https://<your-project-ref>.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<publishable-key>
 SUPABASE_SECRET_KEY=<secret-key>
 SUPABASE_JWT_SECRET=<jwt-secret>
+SUPABASE_ACCESS_TOKEN=<access-token>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: 1.44.0
+      - run: npm run deno:check
       - run: npm test
       - name: Install admin dependencies
         run: npm install --legacy-peer-deps

--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ Visit `http://localhost:3000`
 ---
 
 ## ☁️ Edge Functions
-- `ingestNews`: pull all feeds every 30m  
-- `generateEpk`: render + store PDFs  
-- `notifyPost`: push notifications  
-- `gigGeo`: geohash utils  
+- `ingestNews`: pull all feeds every 30m
+- `generateEpk`: render + store PDFs
+- `notifyPost`: push notifications
+- `gigGeo`: geohash utils
 
-Deploy:
+Deploy (needs `SUPABASE_ACCESS_TOKEN`):
 ```bash
+export SUPABASE_ACCESS_TOKEN=<access-token>
 supabase functions deploy ingestNews
 ```
 

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,9 @@
+{
+  "expo": {
+    "name": "mobile",
+    "slug": "mobile",
+    "android": {
+      "package": "com.thecueroom.mobile"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint . --ext .ts,.tsx,.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "jest",
-    "build": "echo 'build step placeholder'"
+    "build": "echo 'build step placeholder'",
+    "deno:check": "npm --prefix supabase run typecheck:deno"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",


### PR DESCRIPTION
## Summary
- document SUPABASE_ACCESS_TOKEN for function deployments
- add android.package to Expo config for APK builds
- run `npm run deno:check` in CI via Deno setup

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm --prefix admin test -- --passWithNoTests`
- `npm --prefix mobile test -- --passWithNoTests`
- `npm run deno:check` *(fails: invalid peer certificate)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b34cd3d044832fbc52f7a5385c5bf6