### PR TITLE
chore: configure Supabase deploy token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy-functions:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - uses: supabase/setup-cli@v1
+      - run: supabase functions deploy ingestNews

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ Visit `http://localhost:3000`
 
 Deploy (needs `SUPABASE_ACCESS_TOKEN`):
 ```bash
-export SUPABASE_ACCESS_TOKEN=<access-token>
+export SUPABASE_ACCESS_TOKEN=<access-token> # locally
 supabase functions deploy ingestNews
 ```
+GitHub Actions uses a real token via `SUPABASE_ACCESS_TOKEN` secret (see `.github/workflows/deploy.yml`).
 
 ---
 


### PR DESCRIPTION
## Summary
- document Supabase token usage
- add deploy workflow using SUPABASE_ACCESS_TOKEN secret

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4042ccd94832fae903affd489f7fc