### PR TITLE
fix: pin supabase cli version

### DIFF
--- a/.github/workflows/deploy-edge.yml
+++ b/.github/workflows/deploy-edge.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: v2.39.2
+          version: 2.39.2
 
       - name: Login
         run: supabase login --token "${SUPABASE_ACCESS_TOKEN}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,4 +18,6 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - uses: supabase/setup-cli@v1
+        with:
+          version: 2.39.2
       - run: supabase functions deploy ingestnews


### PR DESCRIPTION
## Summary
- pin supabase/setup-cli to 2.39.2 in deploy workflows

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run deno:check` *(fails: deno: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b412033778832f9e92e46463a9b11f