### PR TITLE
feat: schedule ingestnews via pg_cron

### DIFF
--- a/.github/workflows/deploy-edge.yml
+++ b/.github/workflows/deploy-edge.yml
@@ -19,14 +19,12 @@ jobs:
           version: 2.39.2
 
       - name: Login
-        run: supabase login --token "${SUPABASE_ACCESS_TOKEN}"
+        run: supabase login --token "$SUPABASE_ACCESS_TOKEN"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Link
-        run: supabase link --project-ref "${SUPABASE_PROJECT_REF}"
-        env:
-          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+        run: supabase link --project-ref heaztitsbnotkozmhubw
 
       - name: Set runtime secrets
         run: |

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,5 +1,2 @@
 [functions.ingestnews]
 verify_jwt = false
-
-[[functions.ingestnews.crons]]
-schedule = "*/30 * * * *"

--- a/supabase/migrations/20250221_schedule_ingestnews.sql
+++ b/supabase/migrations/20250221_schedule_ingestnews.sql
@@ -1,0 +1,35 @@
+-- Ensure pg_net is available (if not, enable it in Dashboard → Database → Extensions)
+-- This migration assumes pg_cron is available in the project.
+
+-- Store the project URL and a token we will use to call the function.
+-- For public (verify_jwt = false) functions, using the anon key is acceptable.
+-- If you prefer a private function, create and validate a custom header instead.
+select vault.create_secret('https://heaztitsbnotkozmhubw.supabase.co', 'project_url') on conflict do nothing;
+select vault.create_secret('REPLACE_WITH_PUBLISHABLE_ANON_KEY', 'anon_key') on conflict do nothing;
+
+-- Drop any existing job with the same name to avoid duplicates.
+select cron.unschedule('invoke-ingestnews-every-30-min') 
+where exists (select 1 from cron.job where jobname = 'invoke-ingestnews-every-30-min');
+
+-- Schedule: every 30 minutes call the Edge Function /functions/v1/ingestnews
+select cron.schedule(
+  'invoke-ingestnews-every-30-min',
+  '*/30 * * * *',
+  $$
+    select
+      net.http_post(
+        url := (select decrypted_secret from vault.decrypted_secrets where name='project_url') || '/functions/v1/ingestnews',
+        headers := jsonb_build_object(
+          'Content-Type','application/json',
+          'Authorization','Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name='anon_key')
+        ),
+        body := jsonb_build_object('scheduled_at', now())
+      ) as request_id;
+  $$
+);
+
+-- Optional visibility while debugging:
+-- select * from cron.job;
+-- select * from cron.job_run_details order by start_time desc limit 20;
+-- select * from net._http_response order by created desc limit 20;
+


### PR DESCRIPTION
## Summary
- strip unsupported cron from ingestnews config
- schedule ingestnews via pg_cron and pg_net
- hardcode project ref in edge-function deploy workflow

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `PATH=$PATH:/root/.deno/bin npm run deno:check` *(fails: invalid peer certificate)*
- `npx supabase@2.39.2 link --project-ref heaztitsbnotkozmhubw` *(fails: Access token not provided)*
- `npx supabase@2.39.2 functions deploy ingestnews` *(fails: Access token not provided)*
- `curl -s -i https://heaztitsbnotkozmhubw.supabase.co/functions/v1/ingestnews | head -n 20` *(404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_68b418986c2c832fad24d441a78b15e3