### PR TITLE
ci: pass Supabase DB password to link step

### DIFF
--- a/.github/workflows/deploy-ingestnews.yml
+++ b/.github/workflows/deploy-ingestnews.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +36,9 @@ jobs:
         run: supabase login --token "$SUPABASE_ACCESS_TOKEN"
 
       - name: Link project
-        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+        env:
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
 
       # Runtime secrets for your function (names must NOT start with SUPABASE_)
       - name: Set function secrets


### PR DESCRIPTION
## Summary
- pass Supabase DB password in deploy-ingestnews workflow for non-interactive linking

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4224c7468832fb5ca34481d840923