### PR TITLE
chore: fix supabase migration and CI workflows

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -10,9 +10,7 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: admin
+    defaults: { run: { working-directory: admin } }
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -34,7 +32,6 @@ jobs:
           npm run lint --if-present
           npm run build
 
-      # Provide org/project so no interactive link/login is needed
       - name: Write Vercel project file
         run: |
           mkdir -p .vercel
@@ -42,12 +39,10 @@ jobs:
           { "orgId": "${{ secrets.VERCEL_ORG_ID }}", "projectId": "${{ secrets.VERCEL_PROJECT_ID }}" }
           JSON
 
-      # Use env-based token instead of --token flag
-      - name: Pull env (production)
+      - name: Pull env (prod)
         run: npx vercel pull --yes --environment=production
 
       - name: Deploy (prebuilt, prod)
         run: |
           npx vercel build --prod
           npx vercel deploy --prebuilt --prod
-

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}   # PAT sbp_...
       SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}     # heaztitsbnotkozmhubw
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}     # database password
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}     # DB password
       DENO_TLS_CA_STORE: system
 
     steps:
@@ -31,15 +31,13 @@ jobs:
       - name: Login
         run: supabase login --token "$SUPABASE_ACCESS_TOKEN"
 
-      # Non-interactive link (uses DB password to skip prompt)
-      - name: Link project
+      - name: Link (non-interactive)
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
 
-      - name: Push migrations
-        run: supabase db push
+      - name: Push migrations (auto-confirm)
+        run: yes | supabase db push
 
-      # Function runtime secrets (avoid SUPABASE_* names)
-      - name: Set function secrets
+      - name: Set function secrets (avoid SUPABASE_* names)
         run: |
           supabase secrets set \
             NEWS_SUPABASE_URL="https://${SUPABASE_PROJECT_REF}.supabase.co" \

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -11,6 +11,8 @@ jobs:
   android:
     runs-on: ubuntu-latest
     defaults: { run: { working-directory: mobile } }
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -19,16 +21,18 @@ jobs:
           cache: npm
           cache-dependency-path: mobile/package-lock.json
 
-      - name: Install deps
+      - name: Install deps (tolerate peer issues)
         run: |
           npm ci || npm ci --legacy-peer-deps
           npx expo install --fix || true
 
-      - name: Expo login
-        uses: expo/expo-github-action@v8
+      - uses: expo/expo-github-action@v8
         with:
           eas-version: latest
-          token: ${{ secrets.EAS_TOKEN }}
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Verify login
+        run: eas whoami
 
       - name: EAS Android build (prod)
         run: eas build --platform android --profile production --non-interactive --no-wait
@@ -36,6 +40,8 @@ jobs:
   ios:
     runs-on: macos-latest
     defaults: { run: { working-directory: mobile } }
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -44,17 +50,18 @@ jobs:
           cache: npm
           cache-dependency-path: mobile/package-lock.json
 
-      - name: Install deps
+      - name: Install deps (tolerate peer issues)
         run: |
           npm ci || npm ci --legacy-peer-deps
           npx expo install --fix || true
 
-      - name: Expo login
-        uses: expo/expo-github-action@v8
+      - uses: expo/expo-github-action@v8
         with:
           eas-version: latest
-          token: ${{ secrets.EAS_TOKEN }}
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Verify login
+        run: eas whoami
 
       - name: EAS iOS build (prod)
         run: eas build --platform ios --profile production --non-interactive --no-wait
-

--- a/supabase/migrations/20250221_schedule_ingestnews.sql
+++ b/supabase/migrations/20250221_schedule_ingestnews.sql
@@ -1,26 +1,75 @@
--- supabase/migrations/20250221_schedule_ingestnews.sql  (update this file)
--- Enable pg_net via Dashboard (Extensions) beforehand.
+-- Ensure pg_cron & pg_net are enabled in Studio > Database > Extensions before running.
 
--- Store (or noop if exists)
-select vault.create_secret('https://heaztitsbnotkozmhubw.supabase.co', 'project_url') on conflict do nothing;
-select vault.create_secret('REPLACE_WITH_PUBLISHABLE_ANON_KEY', 'anon_key') on conflict do nothing;
+-----------------------------
+-- Upsert Vault: project_url
+-----------------------------
+do $$
+declare sid uuid;
+begin
+  select id into sid from vault.decrypted_secrets where name = 'project_url' limit 1;
 
--- Replace existing cron job if present
-select cron.unschedule('invoke-ingestnews-every-30-min')
-where exists (select 1 from cron.job where jobname='invoke-ingestnews-every-30-min');
-
--- Schedule: every 30 minutes call the function
-select cron.schedule(
-  'invoke-ingestnews-every-30-min',
-  '*/30 * * * *',
-  $$
-    select net.http_post(
-      url := (select decrypted_secret from vault.decrypted_secrets where name='project_url') || '/functions/v1/ingestnews',
-      headers := jsonb_build_object(
-        'Content-Type','application/json',
-        'Authorization','Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name='anon_key')
-      ),
-      body := jsonb_build_object('scheduled_at', now())
+  if sid is null then
+    perform vault.create_secret(
+      'https://heaztitsbnotkozmhubw.supabase.co',
+      'project_url',
+      'Base URL for this Supabase project'
     );
-  $$
-);
+  else
+    perform vault.update_secret(
+      sid,
+      'https://heaztitsbnotkozmhubw.supabase.co',
+      'project_url',
+      'Base URL for this Supabase project'
+    );
+  end if;
+end $$;
+
+---------------------------
+-- Upsert Vault: anon_key
+---------------------------
+do $$
+declare sid uuid;
+begin
+  -- Replace placeholder before applying, or update via SQL after db push.
+  select id into sid from vault.decrypted_secrets where name = 'anon_key' limit 1;
+
+  if sid is null then
+    perform vault.create_secret(
+      'REPLACE_WITH_PUBLISHABLE_ANON_KEY',
+      'anon_key',
+      'Publishable anon key used to call Edge Functions from cron'
+    );
+  else
+    perform vault.update_secret(
+      sid,
+      'REPLACE_WITH_PUBLISHABLE_ANON_KEY',
+      'anon_key',
+      'Publishable anon key used to call Edge Functions from cron'
+    );
+  end if;
+end $$;
+
+-----------------------------------------
+-- (Re)Schedule the ingestnews invocation
+-----------------------------------------
+-- Remove any existing job with same name
+select cron.unschedule('invoke-ingestnews-every-30-min')
+where exists (select 1 from cron.job where jobname = 'invoke-ingestnews-every-30-min');
+
+-- Schedule: every 30 minutes
+select
+  cron.schedule(
+    'invoke-ingestnews-every-30-min',
+    '*/30 * * * *',
+    $$
+      select net.http_post(
+        url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url')
+               || '/functions/v1/ingestnews',
+        headers := jsonb_build_object(
+          'Content-Type','application/json',
+          'Authorization','Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'anon_key')
+        ),
+        body := jsonb_build_object('scheduled_at', now())
+      );
+    $$
+  );


### PR DESCRIPTION
## Summary
- ensure `react-native-maps` stays at 1.20.1 with Expo SDK 51
- add idempotent Vault secrets + pg_cron scheduler for `ingestnews`
- wire up non-interactive Vercel, Supabase, and Expo build pipelines

## Testing
- `npm test`
- `npm run lint`
- `DENO_TLS_CA_STORE=system npm run deno:check`


------
https://chatgpt.com/codex/tasks/task_e_68b43b0af174832f9c7b6e495b7cd273