### PR TITLE
feat: enable pg_cron and pg_net

### DIFF
--- a/supabase/migrations/20250221_schedule_ingestnews.sql
+++ b/supabase/migrations/20250221_schedule_ingestnews.sql
@@ -1,4 +1,6 @@
--- Ensure pg_cron & pg_net are enabled in Studio > Database > Extensions before running.
+-- Ensure pg_cron & pg_net are available
+create extension if not exists pg_cron with schema extensions;
+create extension if not exists pg_net with schema extensions;
 
 -----------------------------
 -- Upsert Vault: project_url


### PR DESCRIPTION
## Summary
- auto-enable pg_cron and pg_net extensions before scheduling cron job

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b45ad8c00c832fb4f433c91698a3b6