### PR TITLE
fix: expand mobile workflow env

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -10,8 +10,13 @@ on:
 jobs:
   android:
     runs-on: ubuntu-latest
-    defaults: { run: { working-directory: mobile } }
-    env: { EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }} }
+    defaults:
+      run:
+        working-directory: mobile
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,7 +29,9 @@ jobs:
           npm ci || npm ci --legacy-peer-deps
           npx expo install --fix || true
       - uses: expo/expo-github-action@v8
-        with: { eas-version: latest, token: ${{ secrets.EXPO_TOKEN }} }
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
       - name: Verify login
         run: eas whoami
       - name: EAS Android build (prod)
@@ -32,8 +39,13 @@ jobs:
 
   ios:
     runs-on: macos-latest
-    defaults: { run: { working-directory: mobile } }
-    env: { EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }} }
+    defaults:
+      run:
+        working-directory: mobile
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -46,7 +58,9 @@ jobs:
           npm ci || npm ci --legacy-peer-deps
           npx expo install --fix || true
       - uses: expo/expo-github-action@v8
-        with: { eas-version: latest, token: ${{ secrets.EXPO_TOKEN }} }
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
       - name: Verify login
         run: eas whoami
       - name: EAS iOS build (prod)


### PR DESCRIPTION
## Summary
- expand mobile workflow defaults and env mapping
- add supabase URL and anon key placeholders from secrets

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: ESLint was configured to run on `<tsconfigRootDir>/next.config.js` but tsconfig doesn't include this file)*

------
https://chatgpt.com/codex/tasks/task_e_68b46ac335e0832f8d51f349b4f93eee