### PR TITLE
docs: add setup guides and local scripts

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,60 @@
+# Setup Guide
+
+Follow these steps to configure and run thecueRoom locally.
+
+## Prerequisites
+- [Node.js](https://nodejs.org/) **20.19.4**
+- [npm](https://www.npmjs.com/) **11.4.2**
+- [Supabase CLI](https://supabase.com/docs/guides/cli) `>=1`
+- [Expo CLI](https://docs.expo.dev/more/expo-cli/) (installed automatically via `npx`)
+
+## 1. Clone and configure
+```bash
+git clone https://github.com/<your-fork>/thecueRoom_mobileapp.git
+cd thecueRoom_mobileapp
+cp .env.example .env
+```
+Populate `.env` with local values.
+
+## 2. Install dependencies
+```bash
+bash scripts/setup.sh
+```
+The script installs root and mobile packages.
+
+## 3. Start local services
+To run everything:
+```bash
+bash scripts/dev.sh
+```
+This will:
+1. Start Supabase (if the CLI is installed)
+2. Launch the Next.js admin console
+3. Launch the Expo mobile app
+
+## 4. Manual commands
+If you prefer manual control:
+```bash
+# Supabase
+supabase start
+
+# Admin web app
+npm --prefix admin run dev
+
+# Mobile app
+npm --prefix mobile run start
+```
+
+## 5. Quality checks
+```bash
+npm test
+npm run typecheck
+npm run lint
+```
+
+## 6. Build
+```bash
+npm run build
+```
+
+You're ready to contribute!

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,45 @@
+# Troubleshooting
+
+Common issues and fixes when working on thecueRoom.
+
+## Supabase CLI missing
+**Error:** `command not found: supabase`
+
+**Fix:**
+```bash
+npm install -g supabase
+```
+
+## ESLint: pages directory cannot be found
+Occurs when running `npm run lint`.
+
+**Fix:**
+- Ensure you're in the repo root
+- Or run:
+```bash
+npm run lint -- --no-error-on-unmatched-pattern
+```
+
+## TypeScript project error for `next.config.js`
+If ESLint complains about `parserOptions.project`, add `next.config.js` to the Admin `tsconfig.json` `include` array.
+
+## `ENOWORKSPACES` when starting admin
+**Error:** `npm error code ENOWORKSPACES`
+
+**Fix:** Use:
+```bash
+npm --prefix admin run dev
+```
+
+## Metro bundler stuck
+If the Expo bundler hangs, clear the cache:
+```bash
+npm --prefix mobile run start -- --clear
+```
+
+## Ports already in use
+Kill existing processes or change ports:
+```bash
+lsof -i :54321 # example
+kill -9 <pid>
+```

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start Supabase if available
+if command -v supabase >/dev/null 2>&1; then
+  echo "Starting Supabase..."
+  supabase start &
+  SUPABASE_PID=$!
+else
+  echo "Supabase CLI not found, skipping database startup" >&2
+fi
+
+# Start admin console
+npm --prefix admin run dev &
+ADMIN_PID=$!
+
+# Start mobile app
+npm --prefix mobile run start &
+MOBILE_PID=$!
+
+trap "kill $ADMIN_PID $MOBILE_PID ${SUPABASE_PID:-} 2>/dev/null" EXIT
+
+wait $ADMIN_PID

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install root workspace packages
+echo "Installing root dependencies..."
+npm install
+
+# Install mobile packages if present
+if [ -d "mobile" ]; then
+  echo "Installing mobile dependencies..."
+  npm --prefix mobile install
+fi
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add step-by-step setup guide and troubleshooting doc
- provide scripts for dependency install and local dev

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: ESLint cannot parse admin/next.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b46c7b6690832f97def65adeab14a7