### PR TITLE
chore: skip Supabase when Docker is absent

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Start Supabase if available
+# Start Supabase if available and Docker is running
 if command -v supabase >/dev/null 2>&1; then
-  echo "Starting Supabase..."
-  supabase start &
-  SUPABASE_PID=$!
+  if docker info >/dev/null 2>&1; then
+    echo "Starting Supabase..."
+    supabase start &
+    SUPABASE_PID=$!
+  else
+    echo "Docker daemon not running, skipping Supabase startup" >&2
+  fi
 else
   echo "Supabase CLI not found, skipping database startup" >&2
 fi


### PR DESCRIPTION
## Summary
- skip `supabase start` when Docker isn't running

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b4793e2df8832fb08660edd7a4a0ec