### PR TITLE
feat(db): enable pg_cron/pg_net before scheduling; idempotent vault & cron

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Link (non-interactive)
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
 
+      - name: Verify extensions (pg_cron & pg_net)
+        run: |
+          supabase db query "select extname from pg_extension where extname in ('pg_cron','pg_net');"
+
       - name: Push migrations (auto-confirm)
         run: yes | supabase db push
 

--- a/supabase/migrations/20250220_enable_cron_pg_net.sql
+++ b/supabase/migrations/20250220_enable_cron_pg_net.sql
@@ -1,0 +1,9 @@
+-- Enable required extensions locally (Supabase Docker image includes them).
+-- NOTE: On hosted Supabase, enable these from Dashboard > Database > Extensions.
+
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- Optional: verify they exist (no-op if missing on hosted where creation isn't allowed)
+-- select * from pg_extension where extname in ('pg_cron','pg_net');
+


### PR DESCRIPTION
## Summary
- enable `pg_cron` and `pg_net` extensions via early migration
- assume extensions exist when scheduling `ingestnews`
- verify required extensions in CI before database push

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint configuration error)*
- `supabase stop` *(fails: Cannot connect to the Docker daemon)*
- `supabase start` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b47f52f16c832fbb0de6e63cb228e6