### PR TITLE
fix: pin react-native-rss-parser to published version

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -24,7 +24,7 @@
     "react-native": "0.79.5",
     "react-native-maps": "1.20.1",
     "react-native-reanimated": "~3.17.4",
-    "react-native-rss-parser": "^1.7.0",
+    "react-native-rss-parser": "^1.5.1",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "~4.6.0",
     "react-native-svg": "15.11.2",


### PR DESCRIPTION
## Summary
- align mobile app with available `react-native-rss-parser` version 1.5.1

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'react-native')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b52e151fc4832fa0179e87527ef588