### PR TITLE
fix: pin react-native-rss-parser version

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -24,7 +24,7 @@
     "react-native": "0.79.5",
     "react-native-maps": "1.20.1",
     "react-native-reanimated": "~3.17.4",
-    "react-native-rss-parser": "^1.7.0",
+    "react-native-rss-parser": "1.5.1",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "~4.6.0",
     "react-native-svg": "15.11.2",


### PR DESCRIPTION
## Summary
- pin `react-native-rss-parser` to 1.5.1 to match available npm release

## Testing
- `npm test`
- `npm test -w mobile` (fails: No tests found)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b74926bc68832fb010296b91824cc3