### PR TITLE
Add Expo start script to mobile package

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "clean:mobile": "rm -rf node_modules package-lock.json .expo .cache .turbo ios/Pods ios/Podfile.lock android/.gradle android/build",
+    "start": "expo start",
     "dev": "expo start -c",
     "test": "jest",
     "postinstall": "npx expo install --fix || true",


### PR DESCRIPTION
## Summary
- add `start` script for the mobile workspace to run Expo

## Testing
- `npm test` (fails: sh: 1: jest: not found)
- `npm --prefix mobile test` (fails: sh: 1: jest: not found)

------
https://chatgpt.com/codex/tasks/task_e_68b74c66ad40832f8b6c0f87a6d054ca