### PR TITLE
chore: speed up setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install all workspace dependencies in one go
+# Install all workspace dependencies in one go without running postinstall scripts
 echo "Installing workspace dependencies..."
-npm install --workspaces
+npm ci --workspaces --include-workspace-root --ignore-scripts --no-fund --no-audit
 
 echo "Setup complete."


### PR DESCRIPTION
## Summary
- avoid running postinstall hooks during setup
- install workspaces with npm ci for consistent deps

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fcb51668832f92c4b4c2667a7e44